### PR TITLE
Utilize data-uid over parsing Maintainer links to account for pathauto.

### DIFF
--- a/src/HubDrop/Bundle/Service/Project.php
+++ b/src/HubDrop/Bundle/Service/Project.php
@@ -599,10 +599,7 @@ class Project {
     $github_user_exists = FALSE;
 
     foreach ($users as $user){
-      $url = $user->getAttribute('href');
-      // @TODO: learn regular expressions
-      $path = explode('/', $url);
-      $uid = array_pop($path);
+      $uid = $user->getAttribute('data-uid');
       $username = $user->getText();
 
       // Lookup github username locally.


### PR DESCRIPTION
Right now my personal d.o page is-

http://drupal.org/u/albert-volkman

Which breaks during this lookup.
